### PR TITLE
disable r_depthPrepass by default for performance

### DIFF
--- a/Sources/Draw/GLSettings.cpp
+++ b/Sources/Draw/GLSettings.cpp
@@ -36,7 +36,7 @@ DEFINE_SPADES_SETTING(r_debugTimingFlush, "0");
 DEFINE_SPADES_SETTING(r_debugTimingFillGap, "0");
 DEFINE_SPADES_SETTING(r_depthOfField, "0");
 DEFINE_SPADES_SETTING(r_depthOfFieldMaxCoc, "0.01");
-DEFINE_SPADES_SETTING(r_depthPrepass, "1");
+DEFINE_SPADES_SETTING(r_depthPrepass, "0");
 DEFINE_SPADES_SETTING(r_dlights, "0");
 DEFINE_SPADES_SETTING(r_exposureValue, "0");
 DEFINE_SPADES_SETTING(r_fogShadow, "0");


### PR DESCRIPTION
i observed a 30 fps increase whenever r_depthPrepass was toggled off on latest release (Revision 12). heres a vid:
https://github.com/nonperforming/openspadesplus/assets/85409780/215455fd-f8e3-400d-ba78-c77d27f8eca3

it seems by disabling r_depthPrepass we can skip this map prerenderer which is probably why the performance improves:
![Screenshot (29)](https://github.com/nonperforming/openspadesplus/assets/85409780/e018cf49-438c-4f8f-b91c-34b1391782f5)
